### PR TITLE
Add Bundler support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-spec/*.yml
+# Bundler
+.bundle
+pkg/*
+Gemfile.lock
+
 .rvmrc
-doc
-pkg
 .rbenv-version
+doc
+spec/*.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/Manifest
+++ b/Manifest
@@ -1,8 +1,0 @@
-LICENCE
-Manifest
-README.rdoc
-Rakefile
-lib/simpleidn.rb
-simpleidn.gemspec
-spec/idn.rb
-spec/test_vectors.rb

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,6 @@
-# encoding: utf-8
-require 'rubygems'
-require 'rake'
-require 'echoe'
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
-Echoe.new('simpleidn', '0.0.5') do |p|
-  p.description    = "This gem allows easy conversion from punycode ACE strings to unicode UTF-8 strings and visa versa."
-  p.url            = "http://github.com/mmriis/simpleidn"
-  p.author         = "Morten Møller Riis"
-  p.email          = "mortenmoellerriis _AT_ gmail.com"
-  p.ignore_pattern = ["tmp/*", "script/*"]
-end
+RSpec::Core::RakeTask.new(:spec)
 
+task :default => :spec

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -17,7 +17,9 @@ class Integer
 end
 
 module SimpleIDN
-    
+
+  VERSION = "0.0.5"
+
   module Punycode
     
     INITIAL_N = 0x80

--- a/simpleidn.gemspec
+++ b/simpleidn.gemspec
@@ -1,0 +1,23 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'simpleidn'
+
+Gem::Specification.new do |spec|
+  spec.name          = "simpleidn"
+  spec.version       = SimpleIDN::VERSION
+  spec.authors       = ["Morten Møller Riis"]
+  spec.email         = ["mortenmoellerriis _AT_ gmail.com"]
+
+  spec.summary       = %q{Punycode ACE to unicode UTF-8 (and vice-versa) string conversion.}
+  spec.description   = %q{This gem allows easy conversion from punycode ACE strings to unicode UTF-8 strings and vice-versa.}
+  spec.homepage      = "https://github.com/mmriis/simpleidn"
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+end

--- a/spec/idn_spec.rb
+++ b/spec/idn_spec.rb
@@ -1,6 +1,4 @@
-# encoding: utf-8
-require 'rspec'
-require 'simpleidn'
+require 'spec_helper'
 require 'test_vectors'
   
 describe "SimpleIDN" do

--- a/spec/idn_spec.rb
+++ b/spec/idn_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 require 'test_vectors'
-  
+
 describe "SimpleIDN" do
   describe "to_unicode" do
     it "should pass all test cases" do
@@ -8,15 +8,15 @@ describe "SimpleIDN" do
         SimpleIDN.to_unicode(vector[1]).should == vector[0]
       end
     end
-    
+
     it "should respect * and not try to decode it" do
       SimpleIDN.to_unicode("*.xn--mllerriis-l8a.com").should == "*.møllerriis.com"
     end
-    
+
     it "should respect leading _ and not try to encode it" do
-		  SimpleIDN.to_unicode("_something.xn--mllerriis-l8a.com").should == "_something.møllerriis.com"
-	  end
-  
+      SimpleIDN.to_unicode("_something.xn--mllerriis-l8a.com").should == "_something.møllerriis.com"
+    end
+
     it "should return nil for nil" do
       SimpleIDN.to_unicode(nil).should be_nil
     end
@@ -25,24 +25,23 @@ describe "SimpleIDN" do
       # https://github.com/mmriis/simpleidn/issues/3
       SimpleIDN.to_unicode('.').should == '.'
     end
-  
   end
-  
+
   describe "to_ascii" do
     it "should pass all test cases" do
       TESTCASES_JOSEFSSON.sort.each do |testcase, vector|
-				SimpleIDN.to_ascii(vector[0]).should == vector[1].downcase
+        SimpleIDN.to_ascii(vector[0]).should == vector[1].downcase
       end
     end
-    
+
     it "should respect * and not try to encode it" do
-			SimpleIDN.to_ascii("*.hello.com").should == "*.hello.com"
-		end
-		
-		it "should respect leading _ and not try to encode it" do
-		  SimpleIDN.to_ascii("_something.example.org").should == "_something.example.org"
-	  end
-		
+      SimpleIDN.to_ascii("*.hello.com").should == "*.hello.com"
+    end
+
+    it "should respect leading _ and not try to encode it" do
+      SimpleIDN.to_ascii("_something.example.org").should == "_something.example.org"
+    end
+
     it "should return nil for nil" do
       SimpleIDN.to_ascii(nil).should be_nil
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'simpleidn'


### PR DESCRIPTION
I have a couple of improvements to suggest, but the entry point to contribute to the lib is a little bit painful because the lib is using some old packaging conventions (I still remember the days before Bundler... ;) ).

This PR adds Bundler support for quick setup and testing. I removed the Echoe dependency, which is no longer needed.

It's now possible to quickly setup the dependencies by running

```
$ bundle
```

and you can run the tests

```
$ rake test
```

No longer manual setup of RSpec and the various libs. Also, packaging a
version is as single as

```
$ rake build
$ gem push pkg/simpleidn-0.0.5.gem
```

You can actually use

```
$ rake release
```

I used the default setup provided by Bundler with

```
$ bundle gem newgemname
```