### PR TITLE
Raise a ConversionError in case of error

### DIFF
--- a/spec/idn_spec.rb
+++ b/spec/idn_spec.rb
@@ -25,6 +25,10 @@ describe "SimpleIDN" do
       # https://github.com/mmriis/simpleidn/issues/3
       SimpleIDN.to_unicode('.').should == '.'
     end
+
+    it "raises when the input is an invalid ACE" do
+      expect { SimpleIDN.to_unicode('xn---') }.to raise_error(SimpleIDN::ConversionError)
+    end
   end
 
   describe "to_ascii" do


### PR DESCRIPTION
I suggest to not use RangeError, since it's a Ruby exception and it makes it very
hard to rescue a conversion error at high level in an application (because the same error could be raised by another Ruby execution).

A library should return a custom error (it could very well extend
RangeError, but in this case I simply used a StandardError).