### PR TITLE
Move to use Encoding

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -4,7 +4,7 @@ This gem allows easy conversion from punycode ACE strings to unicode UTF-8 strin
 
 The implementation is heavily based on the RFC3492 C example implementation but simplified since it does not preserve case.
 
-This gem works with Ruby 1.8.7, 1.9.2, 1.9.3, 2.0, 2.1, 2.2.
+This gem works with Ruby 1.9.2, 1.9.3, 2.0, 2.1, 2.2.
 
 * http://www.whatastruggle.com
 

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -181,7 +181,7 @@ module SimpleIDN
             raise(ConversionError, "punycode_overflow(2)") if delta > MAXINT
           end
 
-          if (char == n)
+          next unless char == n
               # Represent delta as a generalized variable-length integer:
               q = delta
               k = BASE
@@ -196,7 +196,6 @@ module SimpleIDN
               bias = adapt(delta, h + 1, h == b)
               delta = 0
               h += 1
-          end
         end
 
         delta += 1

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -233,7 +233,7 @@ module SimpleIDN
     return domain if domain_array.length == 0
     out = []
     domain_array.each do |s|
-      out << (s =~ /^xn\-\-/i ? Punycode.decode(s.gsub('xn--','')) : s)
+      out << (s =~ /^xn\-\-/i ? Punycode.decode(s[4..-1]) : s)
     end
     out.join(".")
   end

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -70,15 +70,6 @@ module SimpleIDN
       return k + (BASE - TMIN + 1) * delta / (delta + SKEW)
     end
 
-    # encode_basic(bcp,flag) forces a basic code point to lowercase if flag is zero,
-    # uppercase if flag is nonzero, and returns the resulting code point.
-    # The code point is unchanged if it is caseless.
-    # The behavior is undefined if bcp is not a basic code point.
-    def encode_basic(bcp, flag)
-      bcp -= (bcp - 97 < 26 ? 1 : 0) << 5
-      return bcp + ((!flag && (bcp - 65 < 26 ? 1 : 0)) << 5)
-    end
-
     # Main decode
     def decode(input)
       output = []

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -171,6 +171,7 @@ module SimpleIDN
           end
 
           next unless char == n
+
           # Represent delta as a generalized variable-length integer:
           q = delta
           k = BASE
@@ -178,7 +179,7 @@ module SimpleIDN
             t = k <= bias ? TMIN : k >= bias + TMAX ? TMAX : k - bias
             break if q < t
             output << encode_digit(t + (q - t) % (BASE - t))
-            q = ( (q - t) / (BASE - t) ).floor
+            q = ((q - t) / (BASE - t)).floor
             k += BASE
           end
           output << encode_digit(q)
@@ -194,11 +195,11 @@ module SimpleIDN
     end
   end
 
-  module_function
-
   ACE_PREFIX = 'xn--'
   DOT = '.'
   LABEL_SEPERATOR_RE = /[.]/
+
+  module_function
 
   # Converts a UTF-8 unicode string to a punycode ACE string.
   # == Example

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -196,7 +196,7 @@ module SimpleIDN
   end
 
   ACE_PREFIX = 'xn--'.encode(Encoding::UTF_8).freeze
-  ASCII_MAX = 0x7E
+  ASCII_MAX = 0x7F
   DOT = '.'.encode(Encoding::UTF_8).freeze
   LABEL_SEPERATOR_RE = /[.]/
 

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -46,12 +46,10 @@ module SimpleIDN
 
     # encode_digit(d,flag) returns the basic code point whose value
     # (when used for representing integers) is d, which needs to be in
-    # the range 0 to base-1. The lowercase form is used unless flag is
-    # nonzero, in which case the uppercase form is used. The behavior
-    # is undefined if flag is nonzero and digit d has no uppercase form.
+    # the range 0 to base-1.
     def encode_digit(d)
       d + 22 + 75 * (d < 26 ? 1 : 0)
-      #  0..25 map to ASCII a..z or A..Z
+      #  0..25 map to ASCII a..z
       # 26..35 map to ASCII 0..9
     end
 

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -208,18 +208,22 @@ module SimpleIDN
 
   module_function
 
+  ACE_PREFIX = 'xn--'
+  DOT = '.'
+  LABEL_SEPERATOR_RE = /[.]/
+
   # Converts a UTF-8 unicode string to a punycode ACE string.
   # == Example
   #   SimpleIDN.to_ascii("møllerriis.com")
   #    => "xn--mllerriis-l8a.com"
   def to_ascii(domain)
-    domain_array = domain.split(".") rescue []
+    domain_array = domain.split(LABEL_SEPERATOR_RE) rescue []
     return domain if domain_array.length == 0
     out = []
     domain_array.each do |s|
-      out << (s =~ /[^A-Z0-9@\-*_]/i ? "xn--" + Punycode.encode(s) : s)
+      out << (s =~ /[^A-Z0-9@\-*_]/i ? ACE_PREFIX + Punycode.encode(s) : s)
     end
-    out.join(".")
+    out.join(DOT)
   end
 
   # Converts a punycode ACE string to a UTF-8 unicode string.
@@ -227,12 +231,12 @@ module SimpleIDN
   #   SimpleIDN.to_unicode("xn--mllerriis-l8a.com")
   #    => "møllerriis.com"
   def to_unicode(domain)
-    domain_array = domain.split(".") rescue []
+    domain_array = domain.split(LABEL_SEPARATOR_RE) rescue []
     return domain if domain_array.length == 0
     out = []
     domain_array.each do |s|
-      out << (s =~ /^xn\-\-/i ? Punycode.decode(s[4..-1]) : s)
+      out << (s.downcase.start_with?(ACE_PREFIX) ? Punycode.decode(s[ACE_PREFIX.length..-1]) : s)
     end
-    out.join(".")
+    out.join(DOT)
   end
 end

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -208,8 +208,7 @@ module SimpleIDN
   #    => "xn--mllerriis-l8a.com"
   def to_ascii(domain)
     return nil if domain.nil?
-    edomain = domain.encode(Encoding::UTF_8)
-    domain_array = edomain.split(LABEL_SEPERATOR_RE) rescue []
+    domain_array = domain.encode(Encoding::UTF_8).split(LABEL_SEPERATOR_RE) rescue []
     return domain if domain_array.length == 0
     out = []
     domain_array.each do |s|
@@ -224,8 +223,7 @@ module SimpleIDN
   #    => "møllerriis.com"
   def to_unicode(domain)
     return nil if domain.nil?
-    edomain = domain.encode(Encoding::UTF_8)
-    domain_array = edomain.split(LABEL_SEPERATOR_RE) rescue []
+    domain_array = domain.encode(Encoding::UTF_8).split(LABEL_SEPERATOR_RE) rescue []
     return domain if domain_array.length == 0
     out = []
     domain_array.each do |s|

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -17,7 +17,6 @@ class Integer
 end
 
 module SimpleIDN
-
   VERSION = "0.0.7"
 
   # The ConversionError is raised when an error occurs during a
@@ -26,7 +25,6 @@ module SimpleIDN
   end
 
   module Punycode
-
     INITIAL_N = 0x80
     INITIAL_BIAS = 72
     DELIMITER = 0x2D
@@ -63,11 +61,11 @@ module SimpleIDN
       delta += (delta / numpoints)
 
       k = 0
-      while delta > (((BASE - TMIN) * TMAX) / 2) do
+      while delta > (((BASE - TMIN) * TMAX) / 2)
         delta /= BASE - TMIN
         k += BASE
       end
-      return k + (BASE - TMIN + 1) * delta / (delta + SKEW)
+      k + (BASE - TMIN + 1) * delta / (delta + SKEW)
     end
 
     # Main decode
@@ -93,7 +91,7 @@ module SimpleIDN
       # basic code points were copied; start at the beginning otherwise.
 
       ic = basic > 0 ? basic + 1 : 0
-      while ic < input.length do
+      while ic < input.length
         # ic is the index of the next character to be consumed,
 
         # Decode a generalized variable-length integer into delta,
@@ -103,7 +101,7 @@ module SimpleIDN
         oldi = i
         w = 1
         k = BASE
-        while true do
+        loop do
           raise(ConversionError, "punycode_bad_input(1)") if ic >= input.length
 
           digit = decode_digit(input[ic].ord)
@@ -137,7 +135,7 @@ module SimpleIDN
         i += 1
       end
 
-      return output.join
+      output.join
     end
 
     # Main encode function
@@ -151,9 +149,7 @@ module SimpleIDN
       bias = INITIAL_BIAS
 
       # Handle the basic code points:
-      output = input.select do |char|
-        char if char < 0x80
-      end
+      output = input.select { |char| char < 0x80 }
 
       h = b = output.length
 
@@ -163,7 +159,7 @@ module SimpleIDN
       output << DELIMITER if b > 0
 
       # Main encoding loop:
-      while h < input.length do
+      while h < input.length
         # All non-basic code points < n have been
         # handled already. Find the next larger one:
 
@@ -181,7 +177,7 @@ module SimpleIDN
         delta += (m - n) * (h + 1)
         n = m
 
-        input.each_with_index do |char, j|
+        input.each_with_index do |char, _|
           if char < n
             delta += 1
             raise(ConversionError, "punycode_overflow(2)") if delta > MAXINT
@@ -191,7 +187,7 @@ module SimpleIDN
               # Represent delta as a generalized variable-length integer:
               q = delta
               k = BASE
-              while true do
+              loop do
                   t = k <= bias ? TMIN : k >= bias + TMAX ? TMAX : k - bias
                   break if q < t
                   output << encode_digit(t + (q - t) % (BASE - t))
@@ -208,9 +204,8 @@ module SimpleIDN
         delta += 1
         n += 1
       end
-      return output.collect {|c| c.to_utf8_character}.join
+      output.collect {|c| c.to_utf8_character}.join
     end
-
   end
 
   module_function
@@ -223,13 +218,10 @@ module SimpleIDN
     domain_array = domain.split(".") rescue []
     return domain if domain_array.length == 0
     out = []
-    i = 0
-    while i < domain_array.length
-      s = domain_array[i]
+    domain_array.each do |s|
       out << (s =~ /[^A-Z0-9@\-*_]/i ? "xn--" + Punycode.encode(s) : s)
-      i += 1
     end
-    return out.join(".")
+    out.join(".")
   end
 
   # Converts a punycode ACE string to a UTF-8 unicode string.
@@ -240,12 +232,9 @@ module SimpleIDN
     domain_array = domain.split(".") rescue []
     return domain if domain_array.length == 0
     out = []
-    i = 0
-    while i < domain_array.length
-      s = domain_array[i]
+    domain_array.each do |s|
       out << (s =~ /^xn\-\-/i ? Punycode.decode(s.gsub('xn--','')) : s)
-      i += 1
     end
-    return out.join(".")
+    out.join(".")
   end
 end

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -197,8 +197,8 @@ module SimpleIDN
 
   ACE_PREFIX = 'xn--'.encode(Encoding::UTF_8).freeze
   ASCII_MAX = 0x7F
-  DOT = '.'.encode(Encoding::UTF_8).freeze
-  LABEL_SEPERATOR_RE = /[.]/
+  DOT = 0x2E.chr(Encoding::UTF_8).freeze
+  LABEL_SEPERATOR_RE = /[\u002e]/
 
   module_function
 

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -70,7 +70,7 @@ module SimpleIDN
 
       input[0, basic].each do |char|
         raise(ConversionError, "Illegal input >= 0x80") if char > ASCII_MAX
-        output << char.chr(Encoding::UTF_8)
+        output << char
       end
 
       # Main decoding loop: Start just after the last delimiter if any
@@ -117,11 +117,11 @@ module SimpleIDN
         i %= out
 
         # Insert n at position i of the output:
-        output.insert(i, n.chr(Encoding::UTF_8))
+        output.insert(i, n)
         i += 1
       end
 
-      output.join(EMPTY).encode(input_encoding)
+      output.collect {|c| c.chr(Encoding::UTF_8)}.join(EMPTY).encode(input_encoding)
     end
 
     # Main encode function


### PR DESCRIPTION
This set of changes switches to using the Encoding class to handle strings rather than pack/unpack.  It avoids the need to monkey patch Integer, change the default encoding, and allows non-UTF-8 encodings to be used.  It also makes the code use more ruby idioms.

The Punycode encode/decode methods are assumed to be independent from the SimpleIDN methods, so both handle string encoding.  The code would be a little faster if SimpleIDN was defined to only take in strings in Unicode and always return UTF-8, but this seemed less flexible.