### PR TITLE
Avoid encoding exception in to_unicode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: ruby
-before_install:
-    - rvm @default,@global do gem uninstall bundler rspec -x
-    - gem install bundler --version '~> 1.11'
-    - gem install rspec --version '~> 3.0'
-    - bundle --version
-    - rake --version
-    - rspec --version
 cache: bundler
+sudo: false
+before_install:
+    - gem install bundler
 rvm:
     - 1.9.2
     - 1.9.3
@@ -14,4 +10,4 @@ rvm:
     - 2.1
     - 2.2
     - jruby
-script: 'rspec spec/idn_spec.rb'
+script: 'bundle exec rspec spec/idn_spec.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source 'https://rubygems.org'
 
-group :test do
-  gem "simplecov"
-end
-
+gem 'simplecov', :require => false, :group => :test
 gem 'codecov', :require => false, :group => :test
 gem 'rspec', :require => false, :group => :test
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
+group :test do
+  gem "simplecov"
+end
+
 gem 'codecov', :require => false, :group => :test
 gem 'rspec', :require => false, :group => :test
 

--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -228,6 +228,14 @@ module SimpleIDN
     domain_array.each do |s|
       out << (s.downcase.start_with?(ACE_PREFIX) ? Punycode.decode(s[ACE_PREFIX.length..-1]) : s)
     end
-    out.join(DOT).encode(domain.encoding)
+    out = out.join(DOT)
+    # Try to convert to the input encoding, but don't error on failure
+    # Given that the input is plain 7-bit ASCII only, converting back
+    # frequently fails.  We will try to allow UTF-16 and Unicode encodings
+    begin
+      out.encode!(domain.encoding)
+    rescue Encoding::UndefinedConversionError
+    end
+    out
   end
 end


### PR DESCRIPTION
My previous changes to use the String encoding had a bad side effect.  If the string passed to `to_unicode` does not have a Unicode-compatible encoding, there is a very high probability of the method throwing an exception when it tries to encode the output into the input encoding.  In these cases it is better to just return UTF-8, which is what the code did before my changes.