### PR TITLE
fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 sudo: false
 before_install:
-    - gem install bundler
+    - gem install bundler -v '1.17.3'
 rvm:
     - 1.9.3
     - 2.0


### PR DESCRIPTION
travis build log says:

```
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 1.17.3. Try installing it with `gem install bundler -v 1.17.3`
```