### PR TITLE
CI: Trust that a bundler version exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 cache: bundler
 sudo: false
-before_install:
-    - gem install bundler
 rvm:
     - 2.3
     - 2.7


### PR DESCRIPTION
This gives us a Bundler 1.x on Ruby 2.3, we'll see if that can be used.