### PR TITLE
README.rdoc: Use rdoc-image directive to show build status badge [ci skip]

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
 == SimpleIDN
 
-{<img src="https://app.travis-ci.com/mmriis/simpleidn.svg?branch=master" alt="Build Status" />}[https://app.travis-ci.com/mmriis/simpleidn]
+{rdoc-image:https://app.travis-ci.com/mmriis/simpleidn.svg?branch=master}[https://app.travis-ci.com/mmriis/simpleidn]
 
 This gem allows easy conversion from punycode ACE strings to unicode UTF-8 strings and visa versa.
 


### PR DESCRIPTION
I learned of the rdoc-image syntax here: https://github.com/ruby/rdoc/issues/93