### PR TITLE
Drop `unf` dependency

### DIFF
--- a/lib/simpleidn.rb
+++ b/lib/simpleidn.rb
@@ -1,6 +1,5 @@
 require 'simpleidn/version'
 require 'simpleidn/uts46mapping'
-require 'unf'
 
 module SimpleIDN
   # The ConversionError is raised when an error occurs during a
@@ -223,7 +222,7 @@ module SimpleIDN
     mapped = str.codepoints.map { |cp| UTS64MAPPING.fetch(cp, cp) }
     mapped = mapped.map { |cp| TRANSITIONAL.fetch(cp, cp) } if transitional
     mapped = mapped.flatten.map { |cp| cp.chr(Encoding::UTF_8) }.join(EMPTY)
-    mapped.to_nfc
+    mapped.unicode_normalize(:nfc)
   end
 
   # Converts a UTF-8 unicode string to a punycode ACE string.

--- a/simpleidn.gemspec
+++ b/simpleidn.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "unf", '~> 0.1.4'
-
   spec.add_development_dependency "rake", "~> 13.0.3"
   spec.add_development_dependency "rspec", "~> 3.10"
 


### PR DESCRIPTION
[Now that Ruby 2.2 is the new minimum](https://github.com/mmriis/simpleidn/commit/eabaced86180de0ee9d10ee9f7a073cd5d8628bc), we can use `unicode_normalize(:nfc)` that ships with Ruby 2.2 and later.

The latest beta version of `unf` does the same under the hood.

This allows `SimpleIDN` to be used in environments where compiling native gems is not available/undesirable.